### PR TITLE
Add missing templates and session check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Sample configuration for Diner POS System
+DATABASE_URL=postgresql://user:password@localhost/dinerpos
+SESSION_SECRET=change-me

--- a/app.py
+++ b/app.py
@@ -330,52 +330,54 @@ with app.app_context():
     import models
     db.create_all()
     
-    # Create default admin user if not exists
+    # Create seed data unless disabled for testing
     from models import User, Settings, UserRole, Language, Table, TableStatus, Category, Item
     from werkzeug.security import generate_password_hash
-    
-    if not User.query.filter_by(username='admin').first():
-        admin_user = User(
-            full_name='System Administrator',
-            username='admin',
-            password_hash=generate_password_hash('admin123'),
-            role=UserRole.ADMIN,
-            is_active=True
-        )
-        db.session.add(admin_user)
-    
-    # Create default settings if not exists
-    if not Settings.query.first():
-        default_settings = Settings(
-            currency='USD',
-            tax_rate=0.10,
-            default_lang=Language.EN,
-            receipt_note='Thank you for your visit!'
-        )
-        db.session.add(default_settings)
-    
-    # Create sample tables if none exist
-    if not Table.query.first():
-        sample_tables = [
-            Table(number='1', seats=2, status=TableStatus.AVAILABLE),
-            Table(number='2', seats=4, status=TableStatus.AVAILABLE),
-            Table(number='3', seats=6, status=TableStatus.AVAILABLE),
-            Table(number='4', seats=2, status=TableStatus.AVAILABLE),
-            Table(number='5', seats=8, status=TableStatus.AVAILABLE),
-            Table(number='6', seats=4, status=TableStatus.AVAILABLE),
-        ]
-        for table in sample_tables:
-            db.session.add(table)
-    
-    # Create sample categories if none exist
-    if not Category.query.first():
-        sample_categories = [
-            Category(name='Appetizers'),
-            Category(name='Main Dishes'),
-            Category(name='Desserts'),
-            Category(name='Beverages'),
-        ]
-        for category in sample_categories:
-            db.session.add(category)
+
+    if not os.environ.get('SKIP_BOOTSTRAP'):
+        # Create default admin user if not exists
+        if not User.query.filter_by(username='admin').first():
+            admin_user = User(
+                full_name='System Administrator',
+                username='admin',
+                password_hash=generate_password_hash('admin123'),
+                role=UserRole.ADMIN,
+                is_active=True
+            )
+            db.session.add(admin_user)
+
+        # Create default settings if not Settings exists
+        if not Settings.query.first():
+            default_settings = Settings(
+                currency='USD',
+                tax_rate=0.10,
+                default_lang=Language.EN,
+                receipt_note='Thank you for your visit!'
+            )
+            db.session.add(default_settings)
+
+        # Create sample tables if none exist
+        if not Table.query.first():
+            sample_tables = [
+                Table(number='1', seats=2, status=TableStatus.AVAILABLE),
+                Table(number='2', seats=4, status=TableStatus.AVAILABLE),
+                Table(number='3', seats=6, status=TableStatus.AVAILABLE),
+                Table(number='4', seats=2, status=TableStatus.AVAILABLE),
+                Table(number='5', seats=8, status=TableStatus.AVAILABLE),
+                Table(number='6', seats=4, status=TableStatus.AVAILABLE),
+            ]
+            for table in sample_tables:
+                db.session.add(table)
+
+        # Create sample categories if none exist
+        if not Category.query.first():
+            sample_categories = [
+                Category(name='Appetizers'),
+                Category(name='Main Dishes'),
+                Category(name='Desserts'),
+                Category(name='Beverages'),
+            ]
+            for category in sample_categories:
+                db.session.add(category)
     
     db.session.commit()

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -64,3 +64,10 @@ def toggle_user(user_id):
     db.session.commit()
     flash(f'User {"activated" if user.is_active else "deactivated"} successfully', 'success')
     return redirect(url_for('auth.users'))
+
+@auth_bp.route('/check_session', methods=['POST'])
+def check_session():
+    """Endpoint used by client script to verify active session."""
+    if current_user.is_authenticated:
+        return '', 204
+    return '', 401

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = diner-pos
+version = 0.1.0
+description = Simple Diner POS System
+
+[options]
+packages = find:
+install_requires =
+    Flask
+    Flask-Login
+    Flask-SQLAlchemy

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -331,3 +331,12 @@
         color: #000 !important;
     }
 }
+/* Extra small screen tweaks */
+@media (max-width: 576px) {
+    .dashboard-card .card-body {
+        padding: 1rem;
+    }
+    .navbar-brand {
+        font-size: 1rem;
+    }
+}

--- a/templates/customers/addresses.html
+++ b/templates/customers/addresses.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block title %}Customer Addresses{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h4 class="mb-0"><i class="fas fa-map-marker-alt me-2"></i>Addresses for {{ customer.name }}</h4>
+          <a href="{{ url_for('customers.customer_detail', customer_id=customer.id) }}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left me-1"></i>Back
+          </a>
+        </div>
+        <div class="card-body">
+          {% if customer.addresses %}
+          <div class="table-responsive">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th>Street</th>
+                  <th>City</th>
+                  <th>Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for addr in customer.addresses %}
+                <tr>
+                  <td>{{ addr.street }}</td>
+                  <td>{{ addr.city }}</td>
+                  <td>{{ addr.notes or '-' }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <p class="text-muted">No addresses found.</p>
+          {% endif %}
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <h5 class="mb-0"><i class="fas fa-plus me-2"></i>Add New Address</h5>
+        </div>
+        <div class="card-body">
+          <form method="POST" action="{{ url_for('customers.new_address', customer_id=customer.id) }}">
+            <div class="mb-3">
+              <label class="form-label">Street</label>
+              <input type="text" name="street" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">City</label>
+              <input type="text" name="city" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Notes</label>
+              <textarea name="notes" class="form-control" rows="2"></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary"><i class="fas fa-save me-1"></i>Save Address</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/inventory/edit_item.html
+++ b/templates/inventory/edit_item.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% block title %}Edit Item{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h4 class="mb-0"><i class="fas fa-edit me-2"></i>Edit Item</h4>
+          <a href="{{ url_for('inventory.inventory') }}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left me-1"></i>Back
+          </a>
+        </div>
+        <div class="card-body">
+          <form method="POST">
+            <div class="mb-3">
+              <label class="form-label">Name</label>
+              <input type="text" name="name" value="{{ item.name }}" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Barcode</label>
+              <input type="text" name="barcode" value="{{ item.barcode }}" class="form-control">
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Category</label>
+              <select name="category_id" class="form-select" required>
+                {% for c in categories %}
+                <option value="{{ c.id }}" {% if item.category_id == c.id %}selected{% endif %}>{{ c.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="row">
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label class="form-label">Unit Price</label>
+                  <input type="number" step="0.01" name="unit_price" value="{{ item.unit_price }}" class="form-control" required>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label class="form-label">Cost Price</label>
+                  <input type="number" step="0.01" name="cost_price" value="{{ item.cost_price }}" class="form-control" required>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label class="form-label">Quantity</label>
+                  <input type="number" name="quantity" value="{{ item.quantity }}" class="form-control" required>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label class="form-label">Low Stock Alert</label>
+                  <input type="number" name="low_stock_alert" value="{{ item.low_stock_alert }}" class="form-control" required>
+                </div>
+              </div>
+            </div>
+            <button type="submit" class="btn btn-primary"><i class="fas fa-save me-1"></i>Update Item</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/inventory/logs.html
+++ b/templates/inventory/logs.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block title %}Inventory Logs{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h4 class="mb-0"><i class="fas fa-history me-2"></i>Inventory Logs</h4>
+          <a href="{{ url_for('inventory.inventory') }}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left me-1"></i>Back
+          </a>
+        </div>
+        <div class="card-body">
+          {% if logs %}
+          <div class="table-responsive">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Item</th>
+                  <th>Change</th>
+                  <th>Reason</th>
+                  <th>User</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for log in logs %}
+                <tr>
+                  <td>{{ log.date.strftime('%Y-%m-%d %H:%M') }}</td>
+                  <td>{{ log.item.name }}</td>
+                  <td>{{ log.quantity_diff }}</td>
+                  <td>{{ log.reason }}</td>
+                  <td>{{ log.user.full_name if log.user else '-' }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <p class="text-muted">No logs available.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/inventory/new_item.html
+++ b/templates/inventory/new_item.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% block title %}New Inventory Item{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h4 class="mb-0"><i class="fas fa-box me-2"></i>Add Item</h4>
+          <a href="{{ url_for('inventory.inventory') }}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left me-1"></i>Back
+          </a>
+        </div>
+        <div class="card-body">
+          <form method="POST">
+            <div class="mb-3">
+              <label class="form-label">Name</label>
+              <input type="text" name="name" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Barcode</label>
+              <input type="text" name="barcode" class="form-control">
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Category</label>
+              <select name="category_id" class="form-select" required>
+                {% for c in categories %}
+                <option value="{{ c.id }}">{{ c.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="row">
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label class="form-label">Unit Price</label>
+                  <input type="number" step="0.01" name="unit_price" class="form-control" required>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label class="form-label">Cost Price</label>
+                  <input type="number" step="0.01" name="cost_price" class="form-control" required>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label class="form-label">Quantity</label>
+                  <input type="number" name="quantity" class="form-control" value="0" required>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label class="form-label">Low Stock Alert</label>
+                  <input type="number" name="low_stock_alert" class="form-control" value="10" required>
+                </div>
+              </div>
+            </div>
+            <button type="submit" class="btn btn-primary"><i class="fas fa-save me-1"></i>Save Item</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/reports/customers_report.html
+++ b/templates/reports/customers_report.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Customers Report{% endblock %}
+{% block content %}
+<div class="container-fluid">
+  <div class="row mb-3">
+    <div class="col-12">
+      <h1 class="h3"><i class="fas fa-users"></i> Customers Report</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-body">
+          <h5>Top Customers</h5>
+          <ul>
+            {% for c in top_customers %}
+            <li>{{ c.name }} - {{ c.total_spent }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/reports/daily_summary.html
+++ b/templates/reports/daily_summary.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Daily Summary{% endblock %}
+{% block content %}
+<div class="container-fluid">
+  <div class="row mb-3">
+    <div class="col-12">
+      <h1 class="h3"><i class="fas fa-calendar-day"></i> Daily Summary</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-body">
+          <p><strong>Sales Today:</strong> {{ today_sales }}</p>
+          <p><strong>Orders Today:</strong> {{ today_order_count }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/reports/inventory_report.html
+++ b/templates/reports/inventory_report.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}Inventory Report{% endblock %}
+{% block content %}
+<div class="container-fluid">
+  <div class="row mb-3">
+    <div class="col-12">
+      <h1 class="h3"><i class="fas fa-boxes"></i> Inventory Report</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-body">
+          <h5>Low Stock Items</h5>
+          <ul>
+            {% for item in low_stock_items %}
+            <li>{{ item.name }} - {{ item.quantity }}</li>
+            {% endfor %}
+          </ul>
+          <h5 class="mt-4">Zero Stock Items</h5>
+          <ul>
+            {% for item in zero_stock_items %}
+            <li>{{ item.name }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/reports/sales_report.html
+++ b/templates/reports/sales_report.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block title %}Sales Report{% endblock %}
+{% block content %}
+<div class="container-fluid">
+  <div class="row mb-3">
+    <div class="col-12">
+      <h1 class="h3"><i class="fas fa-chart-line"></i> Sales Report</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-body">
+          <p><strong>Total Sales:</strong> {{ total_sales }}</p>
+          <p><strong>Total Orders:</strong> {{ total_orders }}</p>
+          <div class="table-responsive">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th>Order ID</th>
+                  <th>Date</th>
+                  <th>Type</th>
+                  <th>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for order in orders %}
+                <tr>
+                  <td>{{ order.id }}</td>
+                  <td>{{ order.date.strftime('%Y-%m-%d') }}</td>
+                  <td>{{ order.order_type.value }}</td>
+                  <td>{{ order.final_total }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/settings/discounts.html
+++ b/templates/settings/discounts.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% block title %}Discounts{% endblock %}
+{% block content %}
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-12">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h3"><i class="fas fa-percentage"></i> Discounts</h1>
+        <a href="{{ url_for('settings.new_discount') }}" class="btn btn-primary">
+          <i class="fas fa-plus"></i> New Discount
+        </a>
+      </div>
+      <div class="card">
+        <div class="card-body">
+          {% if discounts %}
+          <div class="table-responsive">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th>Type</th>
+                  <th>Value</th>
+                  <th>Min Purchase</th>
+                  <th>Start</th>
+                  <th>End</th>
+                  <th>Status</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for d in discounts %}
+                <tr>
+                  <td>{{ d.type }}</td>
+                  <td>{{ d.value }}</td>
+                  <td>{{ d.min_purchase }}</td>
+                  <td>{{ d.start_date.strftime('%Y-%m-%d') }}</td>
+                  <td>{{ d.end_date.strftime('%Y-%m-%d') }}</td>
+                  <td>
+                    <span class="badge {{ 'bg-success' if d.is_active else 'bg-secondary' }}">
+                      {{ 'Active' if d.is_active else 'Inactive' }}
+                    </span>
+                  </td>
+                  <td>
+                    <a href="{{ url_for('settings.toggle_discount', discount_id=d.id) }}" class="btn btn-sm btn-outline-primary">
+                      Toggle
+                    </a>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <p class="text-muted">No discounts defined.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/settings/new_discount.html
+++ b/templates/settings/new_discount.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block title %}New Discount{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h4 class="mb-0"><i class="fas fa-percentage me-2"></i>Create Discount</h4>
+          <a href="{{ url_for('settings.discounts') }}" class="btn btn-outline-secondary"><i class="fas fa-arrow-left me-1"></i>Back</a>
+        </div>
+        <div class="card-body">
+          <form method="POST">
+            <div class="mb-3">
+              <label class="form-label">Type</label>
+              <select name="type" class="form-select" required>
+                <option value="Fixed">Fixed</option>
+                <option value="Percentage">Percentage</option>
+              </select>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Value</label>
+              <input type="number" name="value" step="0.01" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Minimum Purchase</label>
+              <input type="number" name="min_purchase" step="0.01" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Start Date</label>
+              <input type="date" name="start_date" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">End Date</label>
+              <input type="date" name="end_date" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary"><i class="fas fa-save me-1"></i>Save Discount</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import pathlib
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['SKIP_BOOTSTRAP'] = '1'
+os.environ['SESSION_SECRET'] = 'test-secret'
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app import app, db
+import pytest
+
+@pytest.fixture(autouse=True, scope='module')
+def setup_database():
+    with app.app_context():
+        db.create_all()
+        yield
+        db.drop_all()
+
+
+def test_dashboard_requires_login():
+    with app.test_client() as client:
+        resp = client.get('/')
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.location


### PR DESCRIPTION
## Summary
- add check_session endpoint for POS session monitoring
- create missing templates for customers, inventory, settings, and reports
- document environment variables in `.env.example`
- add `setup.cfg` for packaging metadata
- adjust CSS for small screens
- add basic pytest test and allow skipping seed data in app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687619d527008321bb907d1c25d58592